### PR TITLE
full-screen warning demo

### DIFF
--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -48,8 +48,14 @@ function onWindowEvent (event, type) {
       document.body.classList.remove('window-blurred')
       try { pages.getActive().webviewEl.focus() } catch (e) {}
       break
-    case 'enter-full-screen': return document.body.classList.add('fullscreen')
-    case 'leave-full-screen': return document.body.classList.remove('fullscreen') 
+    case 'enter-full-screen': 
+      document.body.classList.add('fullscreen')
+      pages.getActive().setFullscreen(true)
+      break
+    case 'leave-full-screen':
+      document.body.classList.remove('fullscreen') 
+      pages.getActive().setFullscreen(false)
+      break
   }
 }
 

--- a/app/shell-window/ui/promptbar.js
+++ b/app/shell-window/ui/promptbar.js
@@ -1,4 +1,5 @@
 import * as yo from 'yo-yo'
+import { findIndex } from 'lodash'
 import * as pages from '../pages'
 
 // globals
@@ -55,7 +56,7 @@ export function remove (page, prompt) {
   if (!page.prompts) { return } // page no longer exists
 
   // find and remove
-  var i = page.prompts.indexOf(prompt)
+  var i = findIndex(page.prompts, prompt)
   if (i !== -1) {
     page.prompts.splice(i, 1)
     update(page)

--- a/app/shell-window/ui/prompts/fullscreen.js
+++ b/app/shell-window/ui/prompts/fullscreen.js
@@ -1,0 +1,37 @@
+import * as yo from 'yo-yo'
+// import { ??? } from 'electron'
+import * as promptbar from '../promptbar'
+
+// constants
+// =
+
+const FULLSCREEN_WARNING_TIME = 2000
+
+// exported api
+// =
+
+export default function () {
+  return {
+    type: 'fullscreen',
+    render: () => { 
+      const onClickClose = () => {
+        console.log('sending leave-full-screen')
+        // ???.send('window-event', 'leave-full-screen')
+      }
+      const alertInitial = yo`
+        <div onclick=${onClickClose} class='prompt push-to-front'>
+          <span>Going fullscreen !</span>
+          <button>EXIT</button>
+        </div>`
+      const alertPersistent = yo`
+        <div onclick=${onClickClose} class='prompt'>
+          <span>Fullscreen</span>
+          <button>EXIT</button>
+      </div>`
+
+      setTimeout(() => yo.update(alertInitial, alertPersistent), FULLSCREEN_WARNING_TIME)
+      return alertInitial
+    }
+  }
+}
+

--- a/app/stylesheets/shell-window/promptbar.less
+++ b/app/stylesheets/shell-window/promptbar.less
@@ -6,6 +6,52 @@
   width: 100%;
 }
 
+body.fullscreen #promptbars {
+  top: 0;
+  height: 10px;
+
+  div {
+    visibility: hidden;
+    background: none;
+    border: none;
+
+    .promptbar {
+      box-shadow: none;
+      .prompt {
+        background-color: #fff;
+        padding: 10px;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        button {
+          margin-left: 1rem;
+          border: 1px #666 solid;
+
+          &:hover {
+            opacity: .8;
+          }
+        }
+
+        &.push-to-front {
+          visibility: visible;
+        }
+      }
+      &:before {
+        display: none;
+      }
+    }
+  }
+
+  &:hover {
+    div { 
+      visibility: visible;
+    }
+  }
+
+}
+
 .promptbar {
   position: relative;
   background: #fff;


### PR DESCRIPTION
I'm experimenting here with how to add a warning that hovers over stuff then is hidden (untill hover).

~~I think this is the right sort of idea, but using the `promptbar` seems like it's not going to work - the dom structure is wrong and it looks like prompts are meant to have a very particular style which is different to a centerer `EXIT fullscreen` hover over.~~

**Proposal**:
- ~~do something similar to this, but make a brand new `div#fullscreen` for the `base.html`~~

EDIT: 90% working!